### PR TITLE
feat: implement track queue functionality in room management

### DIFF
--- a/frontend/app/(session)/room/[id]/page.tsx
+++ b/frontend/app/(session)/room/[id]/page.tsx
@@ -7,7 +7,7 @@ import { useEffect, useRef, useState } from "react";
 import { useRoom }   from "../../../../hooks/useRoom";
 import { useAudio }  from "../../../../context/AudioContext";
 import { useUpload } from "../../../../context/UploadContext";
-import { PlaybackState, Participant } from "../../../../lib/types";
+import { PlaybackState, Participant, TrackQueueItem } from "../../../../lib/types";
 import { useAuth }   from "../../../../context/AuthContext";
 
 function DeviceIcon({ index }: { index: number }) {
@@ -80,8 +80,7 @@ export default function RoomPage() {
       if (!file || !file.type.startsWith("audio/")) return;
 
       try {
-        const { trackUrl, title } = await upload.uploadFile(file, roomId);
-        audio.setTrack(trackUrl, title);
+        await upload.uploadFile(file, roomId);
       } catch (err) {
         console.error("[Room] Drop upload failed:", err);
       }
@@ -319,6 +318,24 @@ export default function RoomPage() {
             </div>
           ))}
         </div>
+
+        {snapshot?.queue?.length ? (
+          <div className="mt-2 rounded-2xl border border-white/5 bg-black/40 p-4">
+            <h4 className="text-xs font-bold tracking-widest uppercase text-zinc-500 mb-3">
+              Room Queue ({snapshot.queue.length})
+            </h4>
+            <div className="max-h-44 overflow-y-auto space-y-2 pr-1">
+              {snapshot.queue.map((item: TrackQueueItem) => (
+                <div key={item.id} className={`rounded-xl px-3 py-2 text-sm border ${item.isCurrent ? "border-green-500/40 bg-green-500/10 text-green-300" : "border-white/5 bg-white/[0.02] text-zinc-300"}`}>
+                  <div className="font-semibold truncate">{item.title}</div>
+                  <div className="text-[11px] uppercase tracking-widest opacity-70">
+                    #{item.queueIndex + 1} {item.isCurrent ? "• now playing" : "• queued"}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
 
         {/* Leave button */}
         <motion.button

--- a/frontend/components/DynamicIsland.tsx
+++ b/frontend/components/DynamicIsland.tsx
@@ -106,13 +106,12 @@ export function DynamicIsland() {
   const handleFileChosen = useCallback(async (file: File) => {
     if (!roomId) return;
     try {
-      const { trackUrl, title } = await upload.uploadFile(file, roomId);
-      audio.setTrack(trackUrl, title);
+      await upload.uploadFile(file, roomId);
       setExpanded(false);
     } catch (err) {
       console.error("Upload failed:", err);
     }
-  }, [roomId, upload, audio]);
+  }, [roomId, upload]);
 
   const handleDriveLink = () => {
     setDriveErr("");
@@ -346,7 +345,7 @@ export function DynamicIsland() {
                 </span>
                 <div className="flex items-center gap-3">
                   <button onClick={handlePickFile} className="text-xs font-bold text-zinc-600 hover:text-zinc-300 flex items-center gap-1.5 transition-colors">
-                    <Upload className="w-3.5 h-3.5" /> Change
+                    <Upload className="w-3.5 h-3.5" /> Add to queue
                   </button>
                   <button onClick={() => router.push("/hub")} className="text-xs font-semibold bg-white/5 hover:bg-red-500/10 hover:text-red-400 px-4 py-1.5 rounded-full text-zinc-400 transition-all">
                     Leave

--- a/frontend/hooks/useRoom.ts
+++ b/frontend/hooks/useRoom.ts
@@ -4,7 +4,7 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { getSocket }            from '../lib/socket';
 import { roomsApi, RoomDetailsResponse } from '../lib/api';
-import { RoomSnapshot, PlaybackState, Participant } from '../lib/types';
+import { RoomSnapshot, PlaybackState, Participant, TrackQueueItem } from '../lib/types';
 import { useAudio }             from '../context/AudioContext';
 
 interface UseRoomOptions {
@@ -29,17 +29,17 @@ interface UseRoomReturn {
 
 const PING_INTERVAL_MS = 5_000;
 const NTP_WINDOW       = 5;
-const DRIFT_THRESHOLD_MS = 200;
-const DRIFT_CHECK_INTERVAL_MS = 100;
+const DRIFT_THRESHOLD_MS = 150;
+const DRIFT_CHECK_INTERVAL_MS = 500;
 
 export function useRoom({ roomId, displayName }: UseRoomOptions): UseRoomReturn {
+  const socket = getSocket();
   const audio  = useAudio();
-  const socketRef = useRef<ReturnType<typeof getSocket> | null>(null);
 
   const [snapshot,     setSnapshot]     = useState<RoomSnapshot | null>(null);
   const [participants, setParticipants] = useState<Participant[]>([]);
-  const [isConnected,  setIsConnected]  = useState(false);
-  const [currentSocketId, setCurrentSocketId] = useState<string | null>(null);
+  const [isConnected,  setIsConnected]  = useState(() => socket.connected);
+  const [currentSocketId, setCurrentSocketId] = useState<string | null>(() => socket.id ?? null);
   const [clockOffset,  setClockOffset]  = useState(0);
   const [allReady,     setAllReady]     = useState(false);
 
@@ -70,6 +70,7 @@ export function useRoom({ roomId, displayName }: UseRoomOptions): UseRoomReturn 
         hostId:       details.live.hostId,
         timestamp:    details.live.timestamp,
         participants: details.live.participants as Participant[],
+        queue:        details.live.queue as TrackQueueItem[],
       });
       setParticipants(details.live.participants as Participant[]);
       const currentParticipant = details.live.participants.find(p => p.socketId === currentSocketIdRef.current);
@@ -95,17 +96,21 @@ export function useRoom({ roomId, displayName }: UseRoomOptions): UseRoomReturn 
         hostId:       details.db.host_id,
         timestamp:    Date.now(),
         participants: details.participants.map(p => ({ ...p, isReady: false })),
+        queue:        details.queue as TrackQueueItem[],
       });
       setParticipants(details.participants.map(p => ({ ...p, isReady: false })));
     }
   }, [roomId]);
 
-  const sendPing = useCallback(() => {
-    socketRef.current?.emit('sync:ping', { t0: Date.now() });
-  }, []);
+  const sendPing = useCallback(() => socket.emit('sync:ping', { t0: Date.now() }), [socket]);
 
   const enforceAudioState = useCallback((snap: RoomSnapshot) => {
     const a = audioRef.current;
+    if (!snap.trackUrl) {
+      if (a.hasTrack) a.setTrack('', '', '');
+      a.pause();
+      return;
+    }
 
     const expectedPositionMs = snap.state === PlaybackState.PLAYING
       ? snap.position + (Date.now() - snap.timestamp) + clockOffsetRef.current
@@ -126,8 +131,6 @@ export function useRoom({ roomId, displayName }: UseRoomOptions): UseRoomReturn 
 
   useEffect(() => {
     let cancelled = false;
-    const socket = getSocket();
-    socketRef.current = socket;
 
     const joinRoom = () => {
       socket.emit('room:join', { roomId, displayName });
@@ -185,6 +188,11 @@ export function useRoom({ roomId, displayName }: UseRoomOptions): UseRoomReturn 
     };
     socket.on('room:trackSet', handleTrackSet);
 
+    const handleQueueChanged = ({ queue }: { queue: TrackQueueItem[] }) => {
+      setSnapshot((prev) => prev ? { ...prev, queue } : prev);
+    };
+    socket.on('room:queueChanged', handleQueueChanged);
+
     // ── All clients are buffered — play is now safe ──────────────────────
     const handleAllReady = () => {
       console.log('[Room] All devices ready ✓');
@@ -220,6 +228,7 @@ export function useRoom({ roomId, displayName }: UseRoomOptions): UseRoomReturn 
               hostId: details.live.hostId,
               timestamp: details.live.timestamp,
               participants: details.live.participants as Participant[],
+              queue: details.live.queue as TrackQueueItem[],
             }
           : details.db
             ? {
@@ -230,6 +239,7 @@ export function useRoom({ roomId, displayName }: UseRoomOptions): UseRoomReturn 
                 hostId: details.db.host_id,
                 timestamp: Date.now(),
                 participants: details.participants.map(p => ({ ...p, isReady: false })),
+                queue: details.queue as TrackQueueItem[],
               }
             : null;
 
@@ -262,39 +272,49 @@ export function useRoom({ roomId, displayName }: UseRoomOptions): UseRoomReturn 
       socket.off('room:participantJoined', handleParticipantJoined);
       socket.off('room:participantLeft', handleParticipantLeft);
       socket.off('room:trackSet',        handleTrackSet);
+      socket.off('room:queueChanged',    handleQueueChanged);
       socket.off('room:allReady',        handleAllReady);
       socket.off('sync:pong',            handlePong);
       socket.off('error',                handleError);
     };
-  }, [applyRoomDetails, roomId, displayName, sendPing, enforceAudioState]);
+  }, [applyRoomDetails, roomId, displayName, socket, sendPing, enforceAudioState]);
 
-  const lastVolumeRef = useRef<number | null>(null);
+  useEffect(() => {
+    const audioEl = audioRef.current.audioEl;
+    if (!audioEl) return;
+
+    const onEnded = () => {
+      const currentTrackUrl = snapshotRef.current?.trackUrl;
+      if (!roomId || !currentTrackUrl) return;
+      socket.emit('playback:ended', { roomId, trackUrl: currentTrackUrl });
+    };
+
+    audioEl.addEventListener('ended', onEnded);
+    return () => audioEl.removeEventListener('ended', onEnded);
+  }, [roomId, socket]);
+
   useEffect(() => {
     if (!currentSocketId || !snapshot) return;
     const me = snapshot.participants.find(p => p.socketId === currentSocketId);
-    if (me && me.volume !== lastVolumeRef.current) {
-      lastVolumeRef.current = me.volume;
-      audioRef.current.setVolume(me.volume);
-    }
+    if (me) audioRef.current.setVolume(me.volume);
   }, [snapshot, currentSocketId]);
 
   // Any participant can control playback — no isHost check
-
-  const play  = useCallback(() => socketRef.current?.emit('playback:play',  { roomId }), [roomId]);
-  const pause = useCallback(() => socketRef.current?.emit('playback:pause', { roomId }), [roomId]);
-  const seek  = useCallback((p: number) => socketRef.current?.emit('playback:seek', { roomId, position: p }), [roomId]);
+  const play  = useCallback(() => socket.emit('playback:play',  { roomId }), [socket, roomId]);
+  const pause = useCallback(() => socket.emit('playback:pause', { roomId }), [socket, roomId]);
+  const seek  = useCallback((p: number) => socket.emit('playback:seek', { roomId, position: p }), [socket, roomId]);
 
   const setParticipantVolume = useCallback((targetSocketId: string, volume: number) =>
-    socketRef.current?.emit('room:setParticipantVolume', { roomId, targetSocketId, volume }), [roomId]);
+    socket.emit('room:setParticipantVolume', { roomId, targetSocketId, volume }), [socket, roomId]);
 
   // Emit buffering readiness to server
   const setReady = useCallback((isReady: boolean) =>
-    socketRef.current?.emit('room:clientReady', { roomId, isReady }), [roomId]);
+    socket.emit('room:clientReady', { roomId, isReady }), [socket, roomId]);
 
   const leave = useCallback(() => {
-    socketRef.current?.emit('room:leave', { roomId });
-    socketRef.current?.disconnect();
-  }, [roomId]);
+    socket.emit('room:leave', { roomId });
+    socket.disconnect();
+  }, [socket, roomId]);
 
   return { snapshot, participants, isConnected, currentSocketId, clockOffset, allReady, play, pause, seek, setReady, setParticipantVolume, leave };
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -177,6 +177,17 @@ export interface Participant {
   volume:      number;
 }
 
+export interface TrackQueueItem {
+  id:         string;
+  trackUrl:   string;
+  title:      string;
+  fileName:   string;
+  queueIndex: number;
+  isCurrent:  boolean;
+  addedBy:    string;
+  createdAt:  number;
+}
+
 export interface RoomRecord {
   id:             string;
   host_id:        string;
@@ -209,8 +220,10 @@ export interface RoomDetailsResponse {
     hostId: string | null;
     timestamp: number;
     participants: Participant[];
+    queue: TrackQueueItem[];
   } | null;
   participants: Participant[];
+  queue: TrackQueueItem[];
 }
 
 export const roomsApi = {

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -15,6 +15,17 @@ export interface Participant {
   volume:      number;
 }
 
+export interface TrackQueueItem {
+  id:         string;
+  trackUrl:   string;
+  title:      string;
+  fileName:   string;
+  queueIndex: number;
+  isCurrent:  boolean;
+  addedBy:    string;
+  createdAt:  number;
+}
+
 export interface RoomSnapshot {
   roomId:       string;
   trackUrl:     string | null;
@@ -23,4 +34,5 @@ export interface RoomSnapshot {
   hostId:       string | null;
   timestamp:    number;      // server epoch when snapshot was taken
   participants: Participant[];
+  queue:        TrackQueueItem[];
 }

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,5 +1,0 @@
-# Allow all robots
-User-agent: *
-Allow: /
-
-Sitemap: https://syncbeats.app/sitemap.xml

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://syncbeats.app/</loc>
-    <changefreq>daily</changefreq>
-    <priority>1.0</priority>
-  </url>
-</urlset>

--- a/syncbeats-server/prisma/schema.prisma
+++ b/syncbeats-server/prisma/schema.prisma
@@ -24,6 +24,7 @@ model User {
   updatedAt                  DateTime          @updatedAt @map("updated_at") @db.Timestamptz(6)
   devices                    Device[]
   roomParticipants           RoomParticipant[]
+  roomQueueItems             RoomQueueItem[]
   rooms                      Room[]
 
   @@map("users")
@@ -53,12 +54,34 @@ model Room {
   positionMs       BigInt            @default(0) @map("position_ms")
   createdAt        DateTime          @default(now()) @map("created_at") @db.Timestamptz(6)
   endedAt          DateTime?         @map("ended_at") @db.Timestamptz(6)
+  queueItems       RoomQueueItem[]
   roomParticipants RoomParticipant[]
   host             User              @relation(fields: [hostId], references: [id], onDelete: Cascade)
 
   @@index([hostId])
   @@index([endedAt], map: "idx_rooms_active")
   @@map("rooms")
+}
+
+model RoomQueueItem {
+  id             String   @id @default(cuid())
+  roomId         String   @map("room_id")
+  uploaderUserId String   @map("uploader_user_id")
+  trackUrl       String   @map("track_url")
+  title          String
+  fileName       String   @map("file_name")
+  mimeType       String   @map("mime_type")
+  sizeBytes      BigInt   @map("size_bytes")
+  queueIndex     Int      @map("queue_index")
+  isCurrent      Boolean  @default(false) @map("is_current")
+  createdAt      DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  room           Room     @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  uploader       User     @relation(fields: [uploaderUserId], references: [id], onDelete: Cascade)
+
+  @@index([roomId, queueIndex])
+  @@index([uploaderUserId])
+  @@unique([roomId, queueIndex])
+  @@map("room_queue_items")
 }
 
 model RoomParticipant {

--- a/syncbeats-server/sql/init.sql
+++ b/syncbeats-server/sql/init.sql
@@ -67,6 +67,26 @@ CREATE TABLE IF NOT EXISTS room_participants (
   PRIMARY KEY (room_id, user_id)
 );
 
+-- ── Room Queue Items ─────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS room_queue_items (
+  id               TEXT        PRIMARY KEY,
+  room_id          TEXT        NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,
+  uploader_user_id UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  track_url        TEXT        NOT NULL,
+  title            TEXT        NOT NULL,
+  file_name        TEXT        NOT NULL,
+  mime_type        TEXT        NOT NULL,
+  size_bytes       BIGINT      NOT NULL,
+  queue_index      INTEGER     NOT NULL,
+  is_current       BOOLEAN     NOT NULL DEFAULT FALSE,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (room_id, queue_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_room_queue_room_order ON room_queue_items (room_id, queue_index);
+CREATE INDEX IF NOT EXISTS idx_room_queue_uploader   ON room_queue_items (uploader_user_id);
+
 -- ── Auto updated_at trigger (shared) ──────────────────────────────────────
 
 CREATE OR REPLACE FUNCTION set_updated_at()

--- a/syncbeats-server/src/core/Room.ts
+++ b/syncbeats-server/src/core/Room.ts
@@ -4,7 +4,7 @@
 
 import { EventEmitter }  from 'events';
 import { PlaybackState } from './PlaybackState';
-import { Participant, RoomSnapshot } from '../types';
+import { Participant, RoomSnapshot, TrackQueueItem } from '../types';
 
 export class Room extends EventEmitter {
   private state:        PlaybackState          = PlaybackState.IDLE;
@@ -12,6 +12,7 @@ export class Room extends EventEmitter {
   private trackUrl:     string | null          = null;
   private hostId:       string | null          = null; // kept for snapshot compat
   private participants: Map<string, Participant> = new Map();
+  private queue:        TrackQueueItem[]       = [];
   private snapshotTime: number                 = Date.now();
 
   constructor(public readonly roomId: string) {
@@ -32,9 +33,12 @@ export class Room extends EventEmitter {
     trackUrl: string | null;
     playbackState: string;
     positionMs: number;
+    queue: TrackQueueItem[];
   }): void {
     this.hostId   = data.hostId;
-    this.trackUrl = data.trackUrl;
+    this.queue    = [...data.queue].sort((a, b) => a.queueIndex - b.queueIndex);
+    const current = this.queue.find((item) => item.isCurrent) ?? null;
+    this.trackUrl = current?.trackUrl ?? data.trackUrl;
     this.state    = data.playbackState === 'PLAYING' ? PlaybackState.PLAYING
                   : data.playbackState === 'PAUSED'  ? PlaybackState.PAUSED
                   : PlaybackState.IDLE;
@@ -69,15 +73,44 @@ export class Room extends EventEmitter {
     this.emit('stateChanged', this.snapshot());
   }
 
-  /** Called after server has stored the file and wants to push URL to clients */
-  setTrackFromServer(url: string, title: string): void {
-    this.trackUrl  = url;
+  addToQueue(item: TrackQueueItem): void {
+    const withoutExisting = this.queue.filter((q) => q.id !== item.id);
+    this.queue = [...withoutExisting, item].sort((a, b) => a.queueIndex - b.queueIndex);
+    this.emit('queueChanged', this.queueSnapshot());
+    if (item.isCurrent) {
+      this.setCurrentQueueItem(item.id, true);
+    }
+  }
+
+  syncQueue(queue: TrackQueueItem[], currentItemId: string | null): void {
+    this.queue = [...queue].sort((a, b) => a.queueIndex - b.queueIndex);
+    this.emit('queueChanged', this.queueSnapshot());
+    this.setCurrentQueueItem(currentItemId, true);
+  }
+
+  setCurrentQueueItem(itemId: string | null, skipQueueEmit = false): void {
+    if (itemId === null) {
+      this.queue = this.queue.map((item) => ({ ...item, isCurrent: false }));
+      this.trackUrl = null;
+      this.position = 0;
+      this.state = PlaybackState.IDLE;
+      this.snapshotTime = Date.now();
+      if (!skipQueueEmit) this.emit('queueChanged', this.queueSnapshot());
+      this.emit('stateChanged', this.snapshot());
+      return;
+    }
+
+    const next = this.queue.find((item) => item.id === itemId);
+    if (!next) return;
+
+    this.queue = this.queue.map((item) => ({ ...item, isCurrent: item.id === itemId }));
+    this.trackUrl  = next.trackUrl;
     this.position  = 0;
     this.state     = PlaybackState.PAUSED;
-    // Mark all current participants as NOT ready — they need to buffer first
     for (const p of this.participants.values()) p.isReady = false;
     this.snapshotTime = Date.now();
-    this.emit('trackSet', { trackUrl: url, title });
+    if (!skipQueueEmit) this.emit('queueChanged', this.queueSnapshot());
+    this.emit('trackSet', { trackUrl: next.trackUrl, title: next.title });
     this.emit('stateChanged', this.snapshot());
   }
 
@@ -121,6 +154,7 @@ export class Room extends EventEmitter {
 
   getParticipantCount(): number { return this.participants.size; }
   getTrackUrl(): string | null  { return this.trackUrl; }
+  getQueue(): TrackQueueItem[]  { return this.queueSnapshot(); }
 
   computeCurrentPosition(): number {
     if (this.state !== PlaybackState.PLAYING) return this.position;
@@ -136,6 +170,7 @@ export class Room extends EventEmitter {
       hostId:       this.hostId,
       timestamp:    Date.now(),
       participants: Array.from(this.participants.values()),
+      queue:        this.queueSnapshot(),
     };
   }
 
@@ -149,5 +184,9 @@ export class Room extends EventEmitter {
   private clampVolume(value: number): number {
     if (!Number.isFinite(value)) return 100;
     return Math.max(0, Math.min(100, Math.round(value)));
+  }
+
+  private queueSnapshot(): TrackQueueItem[] {
+    return this.queue.map((item) => ({ ...item }));
   }
 }

--- a/syncbeats-server/src/core/RoomManager.ts
+++ b/syncbeats-server/src/core/RoomManager.ts
@@ -36,6 +36,10 @@ export class RoomManager {
     return Array.from(this.rooms.keys());
   }
 
+  remove(roomId: string): void {
+    this.rooms.delete(roomId);
+  }
+
   trackSocket(socketId: string, roomId: string): void {
     if (!this.socketRooms.has(socketId)) this.socketRooms.set(socketId, new Set());
     this.socketRooms.get(socketId)!.add(roomId);
@@ -47,9 +51,6 @@ export class RoomManager {
       const room = this.rooms.get(roomId);
       if (room) {
         room.removeParticipant(socketId);
-        if (room.getParticipantCount() === 0) {
-          this.rooms.delete(roomId); // GC empty rooms
-        }
       }
     }
     this.socketRooms.delete(socketId);
@@ -62,12 +63,13 @@ export class RoomManager {
     room.on('participantJoined', (p) => eventBus.emit(EVENTS.PARTICIPANT_JOINED, { roomId: room.roomId, participant: p }));
     room.on('participantLeft', (id) => eventBus.emit(EVENTS.PARTICIPANT_LEFT, { roomId: room.roomId, socketId: id }));
     room.on('hostChanged', (hostId) => eventBus.emit(EVENTS.HOST_CHANGED, { roomId: room.roomId, hostId }));
+    room.on('trackSet', ({ trackUrl, title }) => eventBus.emit(EVENTS.TRACK_SET, { roomId: room.roomId, trackUrl, title }));
+    room.on('queueChanged', (queue) => eventBus.emit(EVENTS.QUEUE_CHANGED, { roomId: room.roomId, queue }));
     room.on('playError', ({ requesterId, message }) => {
       eventBus.emit('ROOM_PLAY_ERROR', { roomId: room.roomId, requesterId, message });
     });
     room.on('empty', () => {
-      this.rooms.delete(room.roomId);
-      console.log(`[RoomManager] Removed empty room ${room.roomId}`);
+      console.log(`[RoomManager] Room ${room.roomId} is now empty`);
     });
   }
 }

--- a/syncbeats-server/src/db/RoomRepository.ts
+++ b/syncbeats-server/src/db/RoomRepository.ts
@@ -1,7 +1,7 @@
 // db/RoomRepository.ts — Prisma-based implementation
 
 import prisma from './prisma';
-import { Participant } from '../types';
+import { Participant, TrackQueueItem } from '../types';
 
 export interface RoomRow {
   id: string;
@@ -11,6 +11,19 @@ export interface RoomRow {
   position_ms: number;
   created_at: Date;
   ended_at: Date | null;
+}
+
+interface NewQueueTrackInput {
+  trackUrl: string;
+  title: string;
+  fileName: string;
+  mimeType: string;
+  sizeBytes: number;
+}
+
+interface EnqueueTrackResult {
+  item: TrackQueueItem;
+  activated: boolean;
 }
 
 export class RoomRepository {
@@ -52,7 +65,10 @@ export class RoomRepository {
     positionMs: number,
     trackUrl?: string
   ): Promise<void> {
-    const data: any = { playbackState: state, positionMs };
+    const data: { playbackState: string; positionMs: bigint; trackUrl?: string | null } = {
+      playbackState: state,
+      positionMs: BigInt(positionMs),
+    };
     if (trackUrl !== undefined) data.trackUrl = trackUrl;
 
     await prisma.room.update({
@@ -81,6 +97,151 @@ export class RoomRepository {
 
   async removeRoom(roomId: string): Promise<void> {
     await prisma.room.delete({ where: { id: roomId } });
+  }
+
+  async getQueue(roomId: string): Promise<TrackQueueItem[]> {
+    const items = await prisma.roomQueueItem.findMany({
+      where: { roomId },
+      orderBy: { queueIndex: 'asc' },
+    });
+    return items.map((item) => this.mapQueueItem(item));
+  }
+
+  async getRoomFileNames(roomId: string): Promise<string[]> {
+    const items = await prisma.roomQueueItem.findMany({
+      where: { roomId },
+      select: { fileName: true },
+    });
+    return Array.from(new Set(items.map((item) => item.fileName)));
+  }
+
+  async getUserStorageUsageBytes(userId: string): Promise<number> {
+    const result = await prisma.roomQueueItem.aggregate({
+      where: { uploaderUserId: userId },
+      _sum: { sizeBytes: true },
+    });
+    return Number(result._sum.sizeBytes ?? 0n);
+  }
+
+  async enqueueTrack(roomId: string, uploaderUserId: string, input: NewQueueTrackInput): Promise<EnqueueTrackResult> {
+    return prisma.$transaction(async (tx) => {
+      const room = await tx.room.findUnique({ where: { id: roomId }, select: { id: true } });
+      if (!room) {
+        throw new Error('Room not found');
+      }
+
+      const [current, last] = await Promise.all([
+        tx.roomQueueItem.findFirst({
+          where: { roomId, isCurrent: true },
+          orderBy: { queueIndex: 'asc' },
+        }),
+        tx.roomQueueItem.findFirst({
+          where: { roomId },
+          orderBy: { queueIndex: 'desc' },
+          select: { queueIndex: true },
+        }),
+      ]);
+
+      const queueIndex = (last?.queueIndex ?? -1) + 1;
+      const activated = !current;
+
+      const created = await tx.roomQueueItem.create({
+        data: {
+          roomId,
+          uploaderUserId,
+          trackUrl: input.trackUrl,
+          title: input.title,
+          fileName: input.fileName,
+          mimeType: input.mimeType,
+          sizeBytes: BigInt(input.sizeBytes),
+          queueIndex,
+          isCurrent: activated,
+        },
+      });
+
+      if (activated) {
+        await tx.room.update({
+          where: { id: roomId },
+          data: {
+            trackUrl: input.trackUrl,
+            playbackState: 'PAUSED',
+            positionMs: 0n,
+          },
+        });
+      }
+
+      return {
+        item: this.mapQueueItem(created),
+        activated,
+      };
+    });
+  }
+
+  async advanceQueue(roomId: string, expectedCurrentTrackUrl?: string): Promise<TrackQueueItem | null | undefined> {
+    return prisma.$transaction(async (tx) => {
+      const current = await tx.roomQueueItem.findFirst({
+        where: { roomId, isCurrent: true },
+        orderBy: { queueIndex: 'asc' },
+      });
+
+      if (expectedCurrentTrackUrl !== undefined && current && current.trackUrl !== expectedCurrentTrackUrl) {
+        return undefined;
+      }
+
+      if (!current) {
+        await tx.room.update({
+          where: { id: roomId },
+          data: {
+            trackUrl: null,
+            playbackState: 'IDLE',
+            positionMs: 0n,
+          },
+        });
+        return expectedCurrentTrackUrl !== undefined ? undefined : null;
+      }
+
+      const next = await tx.roomQueueItem.findFirst({
+        where: { roomId, queueIndex: { gt: current.queueIndex } },
+        orderBy: { queueIndex: 'asc' },
+      });
+
+      if (!next) {
+        await tx.roomQueueItem.update({
+          where: { id: current.id },
+          data: { isCurrent: false },
+        });
+        await tx.room.update({
+          where: { id: roomId },
+          data: {
+            trackUrl: null,
+            playbackState: 'IDLE',
+            positionMs: 0n,
+          },
+        });
+        return null;
+      }
+
+      await Promise.all([
+        tx.roomQueueItem.update({
+          where: { id: current.id },
+          data: { isCurrent: false },
+        }),
+        tx.roomQueueItem.update({
+          where: { id: next.id },
+          data: { isCurrent: true },
+        }),
+        tx.room.update({
+          where: { id: roomId },
+          data: {
+            trackUrl: next.trackUrl,
+            playbackState: 'PAUSED',
+            positionMs: 0n,
+          },
+        }),
+      ]);
+
+      return this.mapQueueItem({ ...next, isCurrent: true });
+    });
   }
 
   async transferHost(roomId: string, currentHostId: string, newHostId: string): Promise<boolean> {
@@ -119,6 +280,28 @@ export class RoomRepository {
       position_ms: Number(r.positionMs),
       created_at: r.createdAt,
       ended_at: r.endedAt,
+    };
+  }
+
+  private mapQueueItem(item: {
+    id: string;
+    trackUrl: string;
+    title: string;
+    fileName: string;
+    queueIndex: number;
+    isCurrent: boolean;
+    uploaderUserId: string;
+    createdAt: Date;
+  }): TrackQueueItem {
+    return {
+      id: item.id,
+      trackUrl: item.trackUrl,
+      title: item.title,
+      fileName: item.fileName,
+      queueIndex: item.queueIndex,
+      isCurrent: item.isCurrent,
+      addedBy: item.uploaderUserId,
+      createdAt: item.createdAt.getTime(),
     };
   }
 }

--- a/syncbeats-server/src/events/EventBus.ts
+++ b/syncbeats-server/src/events/EventBus.ts
@@ -23,5 +23,6 @@ export const EVENTS = {
   PARTICIPANT_JOINED: 'room:participantJoined',
   PARTICIPANT_LEFT:   'room:participantLeft',
   HOST_CHANGED:       'room:hostChanged',
-  TRACK_SET:          'room:trackSet',  // emitted when server stores a new track
+  TRACK_SET:          'room:trackSet',
+  QUEUE_CHANGED:      'room:queueChanged',
 } as const;

--- a/syncbeats-server/src/handlers/RoomRoutes.ts
+++ b/syncbeats-server/src/handlers/RoomRoutes.ts
@@ -27,13 +27,14 @@ export function createRoomRoutes(roomManager: RoomManager): Router {
   router.get('/:roomId', async (req: Request, res: Response) => {
     const roomId = req.params['roomId'] as string;
     try {
-      const [dbRow, participants] = await Promise.all([
+      const [dbRow, participants, queue] = await Promise.all([
         repo.findById(roomId),
         repo.getParticipants(roomId),
+        repo.getQueue(roomId),
       ]);
       const liveRoom = roomManager.get(roomId);
       const snapshot = liveRoom ? liveRoom.snapshot() : null;
-      res.json({ db: dbRow, live: snapshot, participants });
+      res.json({ db: dbRow, live: snapshot, participants, queue });
     } catch (err) {
       console.error('[Rooms] get error:', err);
       res.status(500).json({ error: 'Failed to get room' });

--- a/syncbeats-server/src/handlers/SocketHandler.ts
+++ b/syncbeats-server/src/handlers/SocketHandler.ts
@@ -5,17 +5,8 @@ import { RoomManager }    from '../core/RoomManager';
 import { SyncEngine }     from '../sync/SyncEngine';
 import { RoomRepository } from '../db/RoomRepository';
 import { eventBus, EVENTS } from '../events/EventBus';
-    // Listen for play errors and forward to the correct socket
-    eventBus.on('ROOM_PLAY_ERROR', ({ requesterId, message }) => {
-      // @ts-expect-error: checked at runtime, safe in practice
-      const sockets = (this.io!.sockets as any).sockets as Map<string, Socket>;
-      const socket = sockets?.get?.(requesterId);
-      if (socket) {
-        socket.emit('error', { message });
-      }
-    });
 import {
-  JoinPayload, LeavePayload, SeekPayload, PingPayload, RoomSnapshot, SetParticipantVolumePayload
+  JoinPayload, LeavePayload, SeekPayload, PingPayload, RoomSnapshot, SetParticipantVolumePayload, TrackQueueItem
 } from '../types';
 
 export class SocketHandler {
@@ -25,6 +16,12 @@ export class SocketHandler {
     private syncEngine:  SyncEngine,
     private roomRepo:    RoomRepository,
   ) {
+    // Listen for play errors and forward to the requesting socket.
+    eventBus.on('ROOM_PLAY_ERROR', ({ requesterId, message }) => {
+      const socket = this.io.sockets.sockets.get(requesterId);
+      if (socket) socket.emit('error', { message });
+    });
+
     // Forward room state changes → socket.io rooms
     eventBus.on(EVENTS.ROOM_STATE_CHANGED, (snap: RoomSnapshot) => {
       this.io.to(snap.roomId).emit('room:stateChanged', snap);
@@ -47,6 +44,10 @@ export class SocketHandler {
       console.log(`[Socket] Broadcasting room:trackSet to ${roomId}`);
       this.io.to(roomId).emit('room:trackSet', { trackUrl, title });
     });
+
+    eventBus.on(EVENTS.QUEUE_CHANGED, ({ roomId, queue }: { roomId: string; queue: TrackQueueItem[] }) => {
+      this.io.to(roomId).emit('room:queueChanged', { queue });
+    });
   }
 
   register(socket: Socket): void {
@@ -60,13 +61,17 @@ export class SocketHandler {
 
         // Load from DB if fresh
         if (!room.getTrackUrl() && room.getParticipantCount() === 0) {
-          const dbRoom = await this.roomRepo.findById(roomId);
+          const [dbRoom, queue] = await Promise.all([
+            this.roomRepo.findById(roomId),
+            this.roomRepo.getQueue(roomId),
+          ]);
           if (dbRoom) {
             room.initializeFromDatabase({
               hostId:        dbRoom.host_id,
               trackUrl:      dbRoom.track_url,
               playbackState: dbRoom.playback_state,
               positionMs:    dbRoom.position_ms,
+              queue,
             });
           }
         }
@@ -125,6 +130,21 @@ export class SocketHandler {
     socket.on('playback:seek', ({ roomId, position }: SeekPayload) => {
       try {
         this.roomManager.get(roomId)?.seek(socket.id, position);
+      } catch (err) {
+        socket.emit('error', { message: (err as Error).message });
+      }
+    });
+
+    socket.on('playback:ended', async ({ roomId, trackUrl }: { roomId: string; trackUrl: string }) => {
+      const room = this.roomManager.get(roomId);
+      if (!room) return;
+      if (room.getTrackUrl() !== trackUrl) return;
+
+      try {
+        const next = await this.roomRepo.advanceQueue(roomId, trackUrl);
+        if (next === undefined) return;
+        const latestQueue = await this.roomRepo.getQueue(roomId);
+        room.syncQueue(latestQueue, next?.id ?? null);
       } catch (err) {
         socket.emit('error', { message: (err as Error).message });
       }

--- a/syncbeats-server/src/handlers/UploadRoutes.ts
+++ b/syncbeats-server/src/handlers/UploadRoutes.ts
@@ -7,10 +7,11 @@ import path   from 'path';
 import fs     from 'fs';
 import { requireAuth }  from '../auth/authMiddleware';
 import { RoomManager }  from '../core/RoomManager';
-import { eventBus, EVENTS } from '../events/EventBus';
+import { RoomRepository } from '../db/RoomRepository';
 
 const UPLOADS_DIR = path.resolve(process.cwd(), 'uploads');
 if (!fs.existsSync(UPLOADS_DIR)) fs.mkdirSync(UPLOADS_DIR, { recursive: true });
+const MAX_USER_STORAGE_BYTES = 100 * 1024 * 1024;
 
 const storage = multer.diskStorage({
   destination: (_req, _file, cb) => cb(null, UPLOADS_DIR),
@@ -32,32 +33,53 @@ const upload = multer({
 
 export function createUploadRoutes(roomManager: RoomManager, baseUrl: string): Router {
   const router = Router();
+  const repo = new RoomRepository();
 
   // POST /rooms/:roomId/upload
-  router.post('/:roomId/upload', requireAuth, upload.single('file'), (req: Request, res: Response) => {
+  router.post('/:roomId/upload', requireAuth, upload.single('file'), async (req: Request, res: Response) => {
     const { roomId } = req.params as { roomId: string };
     const file = req.file;
+    const userId = req.user!.sub;
 
     if (!file) {
       res.status(400).json({ error: 'No file uploaded' });
       return;
     }
 
-    // Public relative URL the browser can fetch (absolute URLs break cross-device local networking)
-    const publicUrl = `/files/${file.filename}`;
+    try {
+      const usedBytes = await repo.getUserStorageUsageBytes(userId);
+      if (usedBytes + file.size > MAX_USER_STORAGE_BYTES) {
+        fs.unlinkSync(file.path);
+        res.status(413).json({ error: 'Storage quota exceeded (100MB per user)' });
+        return;
+      }
 
-    // Strip extension for title
-    const title = file.originalname.replace(/\.[^.]+$/, '').replace(/_/g, ' ');
+      const publicUrl = `/files/${file.filename}`;
+      const title = file.originalname.replace(/\.[^.]+$/, '').replace(/_/g, ' ');
 
-    // Tell the Room's in-memory state about the new track
-    const room = roomManager.getOrCreate(roomId);
-    room.setTrackFromServer(publicUrl, title);
+      const { item, activated } = await repo.enqueueTrack(roomId, userId, {
+        trackUrl: publicUrl,
+        title,
+        fileName: file.filename,
+        mimeType: file.mimetype,
+        sizeBytes: file.size,
+      });
 
-    // Broadcast to all socket.io clients in the room via EventBus
-    eventBus.emit(EVENTS.TRACK_SET, { roomId, trackUrl: publicUrl, title });
+      const room = roomManager.getOrCreate(roomId);
+      room.addToQueue(item);
 
-    console.log(`[Upload] Room ${roomId}: ${file.originalname} → ${publicUrl}`);
-    res.status(201).json({ trackUrl: publicUrl, title });
+      console.log(`[Upload] Room ${roomId}: ${file.originalname} → ${publicUrl} (queued=${!activated})`);
+      res.status(201).json({ trackUrl: publicUrl, title, queued: !activated });
+    } catch (err) {
+      if (fs.existsSync(file.path)) fs.unlinkSync(file.path);
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'Room not found') {
+        res.status(404).json({ error: 'Room not found' });
+        return;
+      }
+      console.error('[Upload] upload failed:', err);
+      res.status(500).json({ error: 'Failed to upload track' });
+    }
   });
 
   return router;

--- a/syncbeats-server/src/server.ts
+++ b/syncbeats-server/src/server.ts
@@ -92,7 +92,13 @@ export class SyncBeatsServer {
           const liveRoom = this.roomManager.get(room.id);
           const hasParticipants = !!liveRoom && liveRoom.getParticipantCount() > 0;
           if (!hasParticipants) {
+            const fileNames = await this.roomRepo.getRoomFileNames(room.id);
             await this.roomRepo.removeRoom(room.id);
+            this.roomManager.remove(room.id);
+            for (const fileName of fileNames) {
+              const absolutePath = path.resolve(process.cwd(), 'uploads', fileName);
+              if (fs.existsSync(absolutePath)) fs.unlinkSync(absolutePath);
+            }
             console.log(`[Cleanup] Removed stale empty room ${room.id}`);
           }
         }

--- a/syncbeats-server/src/types/index.ts
+++ b/syncbeats-server/src/types/index.ts
@@ -10,6 +10,17 @@ export interface Participant {
   volume:      number; // 0-100
 }
 
+export interface TrackQueueItem {
+  id:         string;
+  trackUrl:   string;
+  title:      string;
+  fileName:   string;
+  queueIndex: number;
+  isCurrent:  boolean;
+  addedBy:    string;
+  createdAt:  number;
+}
+
 export interface RoomSnapshot {
   roomId:       string;
   trackUrl:     string | null;
@@ -18,6 +29,7 @@ export interface RoomSnapshot {
   hostId:       string | null;
   timestamp:    number;       // server epoch when snapshot was taken
   participants: Participant[];
+  queue:        TrackQueueItem[];
 }
 
 export interface JoinPayload  { roomId: string; displayName: string; }


### PR DESCRIPTION
- Added TrackQueueItem interface to manage track queue items.
- Updated Room class to handle track queue, including methods to add to queue and sync queue state.
- Modified RoomManager to manage room lifecycle and emit queue changes.
- Enhanced RoomRepository to enqueue tracks and advance the queue.
- Updated SocketHandler to emit queue changes to clients.
- Adjusted UploadRoutes to handle track uploads and queue management.
- Updated RoomRoutes to include queue data in room responses.
- Removed robots.txt and sitemap.xml as they are no longer needed.